### PR TITLE
Update top bar text to image (#714)

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
@@ -29,6 +29,7 @@ import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
 import org.greenstand.android.TreeTracker.view.BorderedTextField
 import org.greenstand.android.TreeTracker.view.LanguageButton
+import org.greenstand.android.TreeTracker.view.TopBarTitle
 
 @Composable
 fun NameEntryView(viewModel: SignupViewModel, state: SignUpState) {
@@ -59,8 +60,12 @@ fun NameEntryView(viewModel: SignupViewModel, state: SignUpState) {
     Scaffold(
         topBar = {
             ActionBar(
-                centerAction = { Text(stringResource(id = R.string.treetracker)) },
-                rightAction = { LanguageButton() }
+                centerAction = {
+                    TopBarTitle()
+                },
+                rightAction = {
+                    LanguageButton()
+                }
             )
         },
         bottomBar = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/Text.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/Text.kt
@@ -1,16 +1,21 @@
 package org.greenstand.android.TreeTracker.view
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
+import org.greenstand.android.TreeTracker.R
 
 @OptIn(ExperimentalUnitApi::class)
 object TextStyles {
@@ -24,10 +29,13 @@ object TextStyles {
 
 @Composable
 fun BoxScope.TopBarTitle() {
-    Text(
-        "TREETRACKER",
-        modifier = Modifier.align(Alignment.Center),
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Bold
+   Image(
+        painter = painterResource(id = R.drawable.logo),
+        contentDescription = "Treetracker icon",
+        modifier = Modifier
+            .height(100.dp)
+            .width(100.dp)
+            .align(Alignment.Center)
+            .padding(all = 15.dp)
     )
 }


### PR DESCRIPTION
* Replaced Treetracker text in Action bar to use image.
Replaced text in NameEntryView.kt action bar to use TopBarTitle() composable

* Replaced Treetracker text in Action bar to use image.
Replaced text in NameEntryView.kt action bar to use TopBarTitle() composable

* Added center alignment.

Co-authored-by: Jonathan Muller <elforama@gmail.com>